### PR TITLE
Add pre-commit hook for the project

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+npm run format:check && \
+npm test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
+    "preinstall": "git config core.hooksPath .githooks",
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",


### PR DESCRIPTION
## Pr add pre-coomit hook
This makes sure we don't commit whoops I forgot to format and check for npm test. 
the pre-commit hooks can be skipped with: `git commit --no-verify -m "Add message"` if need. 
the hooks get installed with npm install, so there is no change in your workflow.
The only thing that is different is:  you can't commit before `npm test` and `npm run format:check` passes. 

## Can't comit? check this
#### Fixing the format error
- `npm run format` 

#### Fixing the lint / test error
- Read the error code from `npm test`
---

It require at least git version 2.9