### PR TITLE
Fix staged file not formatted

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,3 +1,12 @@
 #!/bin/sh
+git diff --full-index --binary > /tmp/stash.$$
+git stash -q --keep-index
+
 npm run format:check && \
 npm test
+RESULT=$?
+
+git apply --whitespace=nowarn < /tmp/stash.$$ && git stash drop -q
+rm /tmp/stash.$$
+
+exit $RESULT


### PR DESCRIPTION
This fixes staged files not formattet to be commited. 

There was an egde case. 
where you have the staged file not formatted and the Dir would have unstated formatted files and you could do the commit. 

This changes it so it removes the unstagede files and run the test and then reapply the unstaged things again.
